### PR TITLE
Generate project URLs correctly from SCM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,9 @@
     <module>core</module>
   </modules>
 
-  <scm>
-    <connection>scm:git@github.com:StyraInc/opa-java-wasm.git</connection>
+  <scm child.scm.connection.inherit.append.path="false" child.scm.developerConnection.inherit.append.path="false" child.scm.url.inherit.append.path="false">
+    <connection>scm:git:https://github.com/StyraInc/opa-java-wasm.git</connection>
+    <developerConnection>scm:git@github.com:StyraInc/opa-java-wasm.git</developerConnection>
     <url>https://github.com/StyraInc/opa-java-wasm.git</url>
   </scm>
 


### PR DESCRIPTION
Maven's SCM inheritance assumes older style SVN style submodule paths by default, turning this off requries the use of a few XML attributes
See: https://maven.apache.org/ref/3.6.1/maven-model-builder/#Inheritance_Assembly

This change also updates the connection/developerConnection. When possible the 'connection' should be a public accessible URL (e.g. no-auth required https://github.com/...), and the developerConnection to the previously used ssh url
See: https://maven.apache.org/pom.html#SCM

Fixes: #32
