### PR TITLE
Migrate to sonatype central portal publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           java-version: 11
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_CENTRAL_TOKEN
           gpg-private-key: ${{ secrets.java_gpg_secret_key }}
@@ -63,8 +63,8 @@ jobs:
         run: |
           mvn --batch-mode clean deploy -Prelease -DskipTests=true -X
         env:
-          MAVEN_USERNAME: ${{ secrets.ossrh_username }}
-          MAVEN_CENTRAL_TOKEN: ${{ secrets.ossrh_password }}
+          MAVEN_USERNAME: ${{ secrets.sonatype_username }}
+          MAVEN_CENTRAL_TOKEN: ${{ secrets.sonatype_password }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.java_gpg_passphrase }}
 
       - name: Back to Snapshot

--- a/pom.xml
+++ b/pom.xml
@@ -35,14 +35,6 @@
     <url>https://github.com/StyraInc/opa-java-wasm.git</url>
   </scm>
 
-  <distributionManagement>
-    <repository>
-      <id>ossrh</id>
-      <name>Central Repository OSSRH</name>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <properties>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
@@ -183,12 +175,6 @@
   <profiles>
     <profile>
       <id>release</id>
-      <distributionManagement>
-        <snapshotRepository>
-          <id>ossrh</id>
-          <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-      </distributionManagement>
       <build>
         <plugins>
           <plugin>
@@ -212,14 +198,14 @@
             </executions>
           </plugin>
           <plugin>
-            <groupId>org.sonatype.plugins</groupId>
-            <artifactId>nexus-staging-maven-plugin</artifactId>
-            <version>${nexus-staging-maven-plugin.version}</version>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>0.7.0</version>
             <extensions>true</extensions>
             <configuration>
-              <serverId>ossrh</serverId>
-              <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+              <publishingServerId>central</publishingServerId>
+              <waitUntil>published</waitUntil>
+              <autoPublish>true</autoPublish>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
Migrated to use https://central.sonatype.org/publish/publish-portal-maven/ instead of https://central.sonatype.org/publish/publish-maven/#deploying-to-ossrh-with-apache-maven

This would need to be merged after:
* We perform the com.styra namespace migration from OSSRH / nexus repository to the new Sonatype central
* We add in `SONATYPE_USERNAME` and `SONATYPE_PASSWORD` secrets to the repo which are currently saved in 1password.