### PR TITLE
Switch to stable annotations and use the compiler

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,6 +15,10 @@
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
+      <artifactId>compiler</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.dylibso.chicory</groupId>
       <artifactId>annotations</artifactId>
     </dependency>
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,7 +15,7 @@
     </dependency>
     <dependency>
       <groupId>com.dylibso.chicory</groupId>
-      <artifactId>host-module-annotations-experimental</artifactId>
+      <artifactId>annotations</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -62,7 +62,7 @@
           <annotationProcessorPaths>
             <path>
               <groupId>com.dylibso.chicory</groupId>
-              <artifactId>host-module-processor-experimental</artifactId>
+              <artifactId>annotations-processor</artifactId>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/core/src/main/java/com/styra/opa/wasm/OpaPolicy.java
+++ b/core/src/main/java/com/styra/opa/wasm/OpaPolicy.java
@@ -188,6 +188,7 @@ public class OpaPolicy {
         private int maxMemory = DEFAULT_MEMORY_MAX;
         private List<OpaBuiltin.Builtin> builtins = new ArrayList<>();
         protected boolean defaultBuiltins = true;
+        private boolean enableCompiler = true;
 
         private Builder() {}
 
@@ -248,6 +249,11 @@ public class OpaPolicy {
             return this;
         }
 
+        public Builder disableCompiler() {
+            this.enableCompiler = false;
+            return this;
+        }
+
         public OpaPolicy build() {
             // Default management
             if (jsonMapper == null) {
@@ -258,7 +264,7 @@ public class OpaPolicy {
             }
             Objects.requireNonNull(is);
 
-            var wasm =
+            var wasmBuilder =
                     OpaWasm.builder()
                             .withInputStream(is)
                             .withJsonMapper(jsonMapper)
@@ -266,10 +272,13 @@ public class OpaPolicy {
                             .withMemory(
                                     new ByteArrayMemory(new MemoryLimits(initialMemory, maxMemory)))
                             .withDefaultBuiltins(defaultBuiltins)
-                            .addBuiltins(builtins.toArray(OpaBuiltin.Builtin[]::new))
-                            .build();
+                            .addBuiltins(builtins.toArray(OpaBuiltin.Builtin[]::new));
 
-            return new OpaPolicy(wasm);
+            if (!enableCompiler) {
+                wasmBuilder.disableCompiler();
+            }
+
+            return new OpaPolicy(wasmBuilder.build());
         }
     }
 }

--- a/core/src/main/java/com/styra/opa/wasm/OpaWasm.java
+++ b/core/src/main/java/com/styra/opa/wasm/OpaWasm.java
@@ -1,6 +1,6 @@
 package com.styra.opa.wasm;
 
-import com.dylibso.chicory.experimental.hostmodule.annotations.WasmModuleInterface;
+import com.dylibso.chicory.annotations.WasmModuleInterface;
 import com.dylibso.chicory.runtime.Instance;
 import com.dylibso.chicory.runtime.Memory;
 import com.dylibso.chicory.wasm.Parser;

--- a/core/src/test/java/com/styra/opa/wasm/OpaTestCasesTest.java
+++ b/core/src/test/java/com/styra/opa/wasm/OpaTestCasesTest.java
@@ -146,6 +146,7 @@ public class OpaTestCasesTest {
                 OpaPolicy.builder()
                         .addBuiltins(customBuiltins)
                         .withPolicy(data.getPolicy())
+                        .disableCompiler()
                         .build();
         assertEquals(1, policy.entrypoints().size());
 

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
     <maven-gpg-plugin.version>3.2.7</maven-gpg-plugin.version>
     <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <chicory.version>1.3.0</chicory.version>
     <junit.version>5.13.0</junit.version>
+    <chicory.version>1.4.0</chicory.version>
     <jackson.version>2.19.0</jackson.version>
     <spotless.version>2.44.5</spotless.version>
   </properties>


### PR DESCRIPTION
I enabled the compiler by default since it's the faster execution option especially if the `OpaPolicy` gets cached.

In the testsuite we are always executing the policies just once, so the `OpaTestCasesTest` test becomes really slow, i.e. the compilation time > execution time(compiler disabled there).