### PR TITLE
Fix broken link in Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -135,7 +135,7 @@ At the moment the following builtins are supported(and, by default, automaticall
 ### Writing the policy
 
 See
-[https://www.openpolicyagent.org/docs/envoy/primer](https://www.openpolicyagent.org/docs/envoy/primer)
+[https://www.openpolicyagent.org/docs/policy-language](https://www.openpolicyagent.org/docs/policy-language)
 
 ### Compiling the policy
 


### PR DESCRIPTION
The linked document for how to write a policy not longer exists. This replacement link seems like it might cover similar material (but I'm guessing, because I don't know the content that was at the now-broken link).