### PR TITLE
Fix UTF-8 encoding in writeResult for multi-byte characters (#176)

### DIFF
--- a/core/src/main/java/com/styra/opa/wasm/OpaWasm.java
+++ b/core/src/main/java/com/styra/opa/wasm/OpaWasm.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.styra.opa.wasm.builtins.Provided;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -195,9 +196,10 @@ public class OpaWasm implements OpaWasm_ModuleImports, OpaWasm_Env {
     }
 
     public int writeResult(String result) {
-        var resultStrAddr = exports.opaMalloc(result.length());
-        memory().writeCString(resultStrAddr, result);
-        var resultAddr = exports.opaJsonParse(resultStrAddr, result.length());
+        var bytes = result.getBytes(StandardCharsets.UTF_8);
+        var resultStrAddr = exports.opaMalloc(bytes.length);
+        memory().write(resultStrAddr, bytes);
+        var resultAddr = exports.opaJsonParse(resultStrAddr, bytes.length);
         exports.opaFree(resultStrAddr);
         return resultAddr;
     }

--- a/core/src/test/java/com/styra/opa/wasm/Issue176Test.java
+++ b/core/src/test/java/com/styra/opa/wasm/Issue176Test.java
@@ -1,0 +1,38 @@
+package com.styra.opa.wasm;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class Issue176Test {
+    static Path wasmFile;
+
+    @BeforeAll
+    public static void beforeAll() throws Exception {
+        wasmFile =
+                OpaCli.compile("issue176", "issue176/emdash_sprintf", "issue176/emdash_literal")
+                        .resolve("policy.wasm");
+    }
+
+    @Test
+    public void emdashSprintf() {
+        var opa = OpaPolicy.builder().withPolicy(wasmFile).build();
+
+        var result = Utils.getResult(opa.entrypoint("issue176/emdash_sprintf").evaluate());
+
+        assertEquals(
+                "requested String value is invalid — please use one of the allowed values",
+                result.asText());
+    }
+
+    @Test
+    public void emdashLiteral() {
+        var opa = OpaPolicy.builder().withPolicy(wasmFile).build();
+
+        var result = Utils.getResult(opa.entrypoint("issue176/emdash_literal").evaluate());
+
+        assertEquals("This contains an em-dash — in a string literal", result.asText());
+    }
+}

--- a/core/src/test/resources/fixtures/issue176/policy.rego
+++ b/core/src/test/resources/fixtures/issue176/policy.rego
@@ -1,0 +1,5 @@
+package issue176
+
+emdash_sprintf := sprintf("requested %s value is invalid — please use one of the allowed values", ["String"])
+
+emdash_literal := "This contains an em-dash — in a string literal"


### PR DESCRIPTION
`writeResult` used `String.length()` (Java char count) for `malloc` and `opaJsonParse`, which undercounts for multi-byte UTF-8 characters like em-dash (U+2014). Encode to UTF-8 bytes first and use byte length.

fixes #176 