### PR TITLE
Add support for %q format verb in sprintf (#175)

### DIFF
--- a/core/src/main/java/com/styra/opa/wasm/builtins/String.java
+++ b/core/src/main/java/com/styra/opa/wasm/builtins/String.java
@@ -64,6 +64,10 @@ public class String {
             if (format.contains("%v")) {
                 format = format.replaceAll("%v", "%s");
             }
+            // %q wraps the string in double quotes (Go/Rego semantics)
+            if (format.contains("%q")) {
+                format = format.replace("%q", "\"%s\"");
+            }
 
             var result = java.lang.String.format(format, args.toArray());
             return TextNode.valueOf(result);

--- a/core/src/test/java/com/styra/opa/wasm/OpaStringBuiltinsTest.java
+++ b/core/src/test/java/com/styra/opa/wasm/OpaStringBuiltinsTest.java
@@ -16,7 +16,8 @@ public class OpaStringBuiltinsTest {
                                 "string-builtins",
                                 "string_builtins/invoke_sprintf",
                                 "string_builtins/integer_fastpath",
-                                "string_builtins/string_example")
+                                "string_builtins/string_example",
+                                "string_builtins/quoted")
                         .resolve("policy.wasm");
     }
 
@@ -45,5 +46,17 @@ public class OpaStringBuiltinsTest {
         var result = Utils.getResult(opa.entrypoint("string_builtins/string_example").evaluate());
 
         assertEquals("my string", result.get("printed").asText());
+    }
+
+    @Test
+    public void quoted() {
+        var opa = OpaPolicy.builder().withPolicy(wasmFile).build();
+
+        var result =
+                Utils.getResult(
+                        opa.entrypoint("string_builtins/quoted")
+                                .evaluate("{\"value\": \"String\"}"));
+
+        assertEquals("requested \"String\" is invalid", result.get("printed").asText());
     }
 }

--- a/core/src/test/resources/fixtures/string-builtins/policy.rego
+++ b/core/src/test/resources/fixtures/string-builtins/policy.rego
@@ -11,3 +11,7 @@ integer_fastpath := {
 string_example := {
   "printed": sprintf("%s", ["my string"])
 }
+
+quoted := {
+  "printed": sprintf("requested %q is invalid", [input.value])
+}


### PR DESCRIPTION
Java's String.format doesn't support %q, so replace it with "%s" to match Go/Rego semantics of wrapping the argument in double quotes.

Fixes #175 